### PR TITLE
feat: Add image fetching and inclusion for reports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,5 +31,8 @@ VOLCENGINE_TTS_ACCESS_TOKEN=xxx
 # LANGSMITH_API_KEY="xxx"
 # LANGSMITH_PROJECT="xxx"
 
+# Unsplash API Key for report images
+UNSPLASH_API_KEY=""
+
 # [!NOTE]
 # For model settings and other configurations, please refer to `docs/configuration_guide.md`

--- a/src/config/configuration.py
+++ b/src/config/configuration.py
@@ -24,6 +24,7 @@ class Configuration:
     mcp_settings: dict = None  # MCP settings, including dynamic loaded tools
     report_style: str = ReportStyle.ACADEMIC.value  # Report style
     enable_deep_thinking: bool = False  # Whether to enable deep thinking
+    unsplash_api_key: Optional[str] = None # API key for Unsplash
 
     @classmethod
     def from_runnable_config(

--- a/src/tools/crawl.py
+++ b/src/tools/crawl.py
@@ -3,7 +3,9 @@
 
 import logging
 from typing import Annotated
+from urllib.parse import urljoin
 
+from bs4 import BeautifulSoup
 from langchain_core.tools import tool
 from .decorators import log_io
 
@@ -16,13 +18,44 @@ logger = logging.getLogger(__name__)
 @log_io
 def crawl_tool(
     url: Annotated[str, "The url to crawl."],
-) -> str:
-    """Use this to crawl a url and get a readable content in markdown format."""
+) -> dict:
+    """
+    Use this to crawl a url.
+    Returns a dictionary containing the URL, readable content in markdown format,
+    and a list of extracted image items.
+    Each image item is a dictionary like: {"type": "image_url", "image_url": {"url": "absolute_image_url"}}
+    """
     try:
         crawler = Crawler()
         article = crawler.crawl(url)
-        return {"url": url, "crawled_content": article.to_markdown()[:1000]}
+
+        markdown_content = article.to_markdown()[:2000] # Increased limit slightly
+
+        # Extract image information using to_message logic
+        message_items = article.to_message()
+        extracted_images = []
+        # We also need to reconstruct the text if to_message() is the sole source of markdown.
+        # For now, let's assume to_markdown() is still primary for text, and we just extract images.
+        # A more robust way would be for Article to have a method that returns both separately.
+
+        # Simplified extraction for now:
+        image_urls_from_article = []
+        soup = BeautifulSoup(article.html_content, "html.parser")
+        for img_tag in soup.find_all("img"):
+            src = img_tag.get("src")
+            if not src or src.startswith("data:image"):
+                continue
+            absolute_url = urljoin(article.url, src) # Use article.url as base
+            # Add some basic filtering if desired, e.g. min width/height if available
+            image_urls_from_article.append({"type": "image_url_from_crawl", "url": absolute_url, "original_alt": img_tag.get("alt", "")})
+
+        return {
+            "url": url,
+            "markdown_content": markdown_content,
+            "extracted_images": image_urls_from_article
+        }
     except BaseException as e:
-        error_msg = f"Failed to crawl. Error: {repr(e)}"
+        error_msg = f"Failed to crawl {url}. Error: {repr(e)}"
         logger.error(error_msg)
-        return error_msg
+        # Return a dictionary in error cases too for consistency, if possible
+        return {"url": url, "error": error_msg, "markdown_content": "", "extracted_images": []}

--- a/web/.env.example
+++ b/web/.env.example
@@ -18,3 +18,6 @@ NEXT_PUBLIC_API_URL=http://localhost:8000/api
 # Github
 GITHUB_OAUTH_TOKEN=xxxx
 
+# Unsplash API Key (can be left empty if not used by backend, but good for consistency)
+# The Python backend will read this from the root .env file
+# NEXT_PUBLIC_UNSPLASH_API_KEY=""


### PR DESCRIPTION
This feature enables the generation of reports with accompanying images.

Key changes:
- Added ImageFetcher class (in src/tools/image_fetcher.py) to handle downloading, processing (resizing, format conversion), and saving images from URLs or Unsplash.
- Images are saved to a public directory (web/public/report_images/) for frontend access.
- Modified background_investigation_node to extract image URLs from Tavily search results if available.
- Introduced a new process_images_node in the graph that runs before the reporter_node.
  - This node uses ImageFetcher to process one suitable image (from collected URLs or Unsplash fallback) and adds it as a Markdown string to the observations list.
- Updated crawl_tool to extract image URLs from crawled pages.
- Adjusted graph builder logic to incorporate the new image processing node.
- Updated configuration to include UNSPLASH_API_KEY.
- The reporter_node now receives image Markdown in its observations and is expected to include it in the final report based on existing prompt instructions.